### PR TITLE
Ü changed from fourKeystrokes to threeKeystrokes (Spanish)

### DIFF
--- a/script.js
+++ b/script.js
@@ -275,8 +275,7 @@ const smallStyle =
       case 'spanish':
         oneKeystroke = /[a-zñ]/g;
         twoKeystrokes = /[A-ZáéíóúÑ]/g;
-        threeKeystrokes = /[ÁÉÍÓÚü]/g;
-        fourKeystrokes = /[Ü]/g;
+        threeKeystrokes = /[ÁÉÍÓÚÜü]/g;
         break;
 
       case 'swedish':


### PR DESCRIPTION
Hi, I'm from spain and I changed in spanish Ü from fourKeystrokes to threeKeystrokes 'cause if you hold the shift while you press the umlaut and the letter u there are only 3 keystrokes.